### PR TITLE
Overwrite marginal() method to properly handle measurement noise (e.g……., uncertainty)

### DIFF
--- a/src/lantern/model/likelihood/likelihoods.py
+++ b/src/lantern/model/likelihood/likelihoods.py
@@ -3,6 +3,8 @@ import torch
 from gpytorch.likelihoods import GaussianLikelihood as BaseGL
 from gpytorch.likelihoods import MultitaskGaussianLikelihood as BaseMGL
 
+from gpytorch.lazy import LazyEvaluatedKernelTensor
+
 
 class GaussianLikelihood(BaseGL):
     """A modification to the base class:`gpytorch.likelihoods.GaussianLikelihood` that supports combined base noise with provided noise.
@@ -43,7 +45,36 @@ class MultitaskGaussianLikelihood(BaseMGL):
 
     def _shaped_noise_covar(self, base_shape, noise=None, *args, **kwargs):
         noise_covar = super()._shaped_noise_covar(base_shape)
+        
         if noise is not None:
             # reshape to match diagonal shape in multitask case
             return noise_covar.add_diag(noise.reshape(noise.shape[0] * noise.shape[1]))
+            
         return noise_covar
+
+    def marginal(self, function_dist, *params, **kwargs):
+        r"""
+        This overwrites the marginal() method in gpytorch._MultitaskGaussianLikelihoodBase.
+        If 'noise' is None, this just calls the super() version of the method.
+        Otherwise, it uses the _shaped_noise_covar() to add the noise to the diagonal of the covariance (see above).
+        """
+
+        if ('noise' in kwargs) and (kwargs['noise'] is not None):
+            mean = function_dist.mean
+            covar = self._shaped_noise_covar(mean.shape, noise=kwargs['noise'])
+            
+            return function_dist.__class__(mean, covar, interleaved=function_dist._interleaved)
+        else:
+            # Similar to the super().marginal() method, except no noise is added
+            #     the overwrite of the _shaped_noise_covar (above), 
+            #     already adds the noise to the diagonal, so the super().marginal() method would add it twice.
+            mean, covar = function_dist.mean, function_dist.lazy_covariance_matrix
+
+            # ensure that sumKroneckerLT is actually called
+            if isinstance(covar, LazyEvaluatedKernelTensor):
+                covar = covar.evaluate_kernel()
+            
+            return function_dist.__class__(mean, covar, interleaved=function_dist._interleaved)
+        
+        
+        


### PR DESCRIPTION
From my testing, the noise parameter was never getting passed to the _shaped_noise_covar() method. So, the measurement uncertainty was not taken into account in the calculations of the loss.

Looking at the code, I think the simplest change needed to handle the measurement noise is to overwrite the marginal() method in the lantern MultitaskGaussianLikelihood class, and explicitely pass the noise parameter to _shaped_noise_covar() (if it exists).